### PR TITLE
fix: use vuejs-translations instead of vuejs-jp

### DIFF
--- a/scripts/checkout.sh
+++ b/scripts/checkout.sh
@@ -1,1 +1,1 @@
-git clone https://github.com/vuejs-jp/ryu-cho.git
+git clone https://github.com/vuejs-translations/ryu-cho.git


### PR DESCRIPTION
### Description

Currently, the ryu-cho repository is owned by the vuejs-translations organization, not vuejs-jp. I don't think it matters because it's automatically redirected, but I think it needs to be changed.
